### PR TITLE
Remove invalid syntax for tap (bottle :unneeded)

### DIFF
--- a/Formula/aws-auth.rb
+++ b/Formula/aws-auth.rb
@@ -3,7 +3,6 @@ class AwsAuth < Formula
   desc "CLI for authenticating against AWS"
   homepage "https://github.com/telia-oss/aws-auth"
   version "0.0.1"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/telia-oss/aws-auth/releases/download/v0.0.1/aws-auth-0.0.1-darwin-amd64.tar.gz"

--- a/Formula/aws-env.rb
+++ b/Formula/aws-env.rb
@@ -6,7 +6,6 @@ class AwsEnv < Formula
   desc "A small binary for securely handling secrets in environment variables on AWS."
   homepage "https://github.com/telia-oss/aws-env"
   version "1.1.0"
-  bottle :unneeded
 
   if OS.mac? && Hardware::CPU.intel?
     url "https://github.com/telia-oss/aws-env/releases/download/v1.1.0/aws-env-1.1.0-darwin-amd64.tar.gz"

--- a/Formula/cloud-connect.rb
+++ b/Formula/cloud-connect.rb
@@ -6,7 +6,6 @@ class CloudConnect < Formula
   desc "CLI for managing transit gateway attachments."
   homepage "https://github.com/telia-oss/cloudconnect"
   version "0.2.1"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/telia-oss/cloudconnect/releases/download/v0.2.1/cloud-connect-0.2.1-darwin-amd64.tar.gz"


### PR DESCRIPTION
Cleans up the taps syntax, `bottle :unneeded` was deprecated by homebrew-core [in June 2021](https://github.com/Homebrew/brew/pull/11239), and no longer has any meaning to the bottler.